### PR TITLE
Update spf.py

### DIFF
--- a/spf.py
+++ b/spf.py
@@ -79,9 +79,12 @@ except ImportError:
     from email.Message import Message
 try:
     # Python standard libarary as of python3.3
-    import ipaddress
-    if bytes is str:
-      from ipaddress import Bytes
+    if (sys.version_info > (3,0)):
+      import ipaddress
+      if bytes is str:
+        from ipaddress import Bytes
+    else:
+      raise ImportError()
 except ImportError:
     try:
         import ipaddr as ipaddress


### PR DESCRIPTION
only import ipaddress module if running python3 else ensure that ipaddr is imported. At least in python 2.7.5 on Centos7 you get ugly exceptions with ipaddress module and unicode. Fixes issue #7
```
import spf
spf.check2('XX.YY.ZZ.YY', 'user@example.com', 'example.com')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/spf.py", line 297, in check2
    receiver=receiver,timeout=timeout,verbose=verbose,querytime=querytime).check()
  File "/usr/lib/python2.7/site-packages/spf.py", line 378, in __init__
    self.set_ip(i)
  File "/usr/lib/python2.7/site-packages/spf.py", line 405, in set_ip
    self.ipaddr = ipaddress.ip_address(i)
  File "/usr/lib/python2.7/site-packages/ipaddress.py", line 163, in ip_address
    ' a unicode object?' % address)
ipaddress.AddressValueError: 'XX.YY.ZZ.YY' does not appear to be an IPv4 or IPv6 address. Did you pass in a bytes (str in Python 2) instead of a unicode object?
```