### PR TITLE
Add missing double quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ options are:
     logging, spf-received header construction, and providing useful rejection
     messages when messages are rejected due to SPF.
 
---default-explanation" or "-default-explanation" {explanation string}: Default
+"--default-explanation" or "-default-explanation" {explanation string}: Default
     Fail explanation string to be used.
 
 "--sanitize" or "-sanitize" and "--debug" or "-debug": These options are no-op


### PR DESCRIPTION
It misses before an parameter example.

By the way, it seems the file is in RestructuredText format and not in Markdown. I think it could be changed to improve the rendering on https://pypi.org/project/pyspf/. Especially the `--` characters are merged into a '–' character which is not what the reader expects to show parameters. (pypi.org renders Mardown correctly now.)
I can do such PR if you are interested. 