### PR TITLE
Downgrade +all pass to ?all neutral

### DIFF
--- a/spf.py
+++ b/spf.py
@@ -936,6 +936,8 @@ class query(object):
                 res = 'neutral'
                 continue
             elif m == 'all':
+                if result == 'pass':
+                  result = 'neutral'
                 break
 
             elif m == 'exists':


### PR DESCRIPTION
+all being a pass is formally correct, but I think it doesn't make sense in
practice for variouse reasons.

As a mail server operator, for sending mails, assuming you aren't just lazy,
+all at the end basically means you want to blacklist instead of whitelist stuff.
But I don't think that actually works. For example, in the past, there used to be
only ip4. So "-ip4:0.0.0.0/1 +all" may have been intended to allow only 128.0.0.0/1,
but since IPv6, it also matches any IPv6 address. Something like that could happen
again in the future. So in such cases, instead of "+all", "+ip:0.0.0.0/0" should
have been used.
TLDR: knowing anything else is authorized to send mails isn't possible, therefore
t is wrong and saying it may or may not be the case, "neutral", is always more
sensible.

In my personal opinion, a blacklisting instead of a whitelisting approach doesn't
ever make much sanse anyway. It may in some special cases save one or two cases,
but it generally just makes the whole thing unnecessarely difficult to understand
and ensure it's actually what you want.

As a mail server operator, for receiving mails, I'm annoyed by lazy OPs just
putting +all in the SPF, as it opens up any spamer to use it. In addition to this,
for ?all neutral cases, I may or may not want to reject mails. But with OPs using
+all, my choice in this matter is sabotaged. In most cases, I don't wan't to
accept that mail, but I get it anyway. So by interpreting +all like ?all instead,
I can get what I actually wanted.