### PR TITLE
Fix doctest registration for Python 3.13

### DIFF
--- a/test/testspf.py
+++ b/test/testspf.py
@@ -225,7 +225,7 @@ def makeSuite(filename):
   return suite
 
 def docsuite():
-  suite = unittest.makeSuite(SPFTestCases,'test')
+  suite = unittest.defaultTestLoader.loadTestsFromTestCase(SPFTestCases)
   try:
     import authres
   except:


### PR DESCRIPTION
`unittest.makeSuite` was deprecated in Python 3.11 and removed in 3.13.