### PR TITLE
Fix syntax warning in Python 3.12

### DIFF
--- a/spf.py
+++ b/spf.py
@@ -1744,7 +1744,7 @@ def quote_value(s):
     >>> quote_value('abc"def')
     '"abc\\\\"def"'
 
-    >>> quote_value(r'abc\def')
+    >>> quote_value(r'abc\\def')
     '"abc\\\\\\\\def"'
 
     >>> quote_value('abc..def')


### PR DESCRIPTION
Although this is written as a raw string, it's within a non-raw docstring, necessitating an extra layer of backslash-escaping.

Contributed by Peter Chubb <peter.chubb@unsw.edu.au> in https://bugs.debian.org/1078728.